### PR TITLE
Topic Metatags [Blocked]

### DIFF
--- a/database/metadata/query_collections.yaml
+++ b/database/metadata/query_collections.yaml
@@ -50,6 +50,7 @@
               image
               created_at
               descriptions {
+                extra_short
                 short
                 long
                 audience

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "Commercial",
       "dependencies": {
-        "prop-types": "^15.8.1"
+        "prop-types": "^15.8.1",
+        "react-helmet": "^6.1.0"
       }
     },
     "node_modules/js-tokens": {
@@ -46,10 +47,49 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Me",
   "license": "Commercial",
   "dependencies": {
-    "prop-types": "^15.8.1"
+    "prop-types": "^15.8.1",
+    "react-helmet": "^6.1.0"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^18.2.0",
         "react-ga4": "^2.1.0",
         "react-helmet": "^6.1.0",
+        "react-helmet-async": "^1.3.0",
         "react-router-dom": "^6.8.1",
         "react-scripts": "^5.0.1",
         "react-test-renderer": "^18.2.0",
@@ -9855,6 +9856,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -15025,6 +15034,22 @@
         "react": ">=16.3.0"
       }
     },
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -15931,6 +15956,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-ga4": "^2.1.0",
+        "react-helmet": "^6.1.0",
         "react-router-dom": "^6.8.1",
         "react-scripts": "^5.0.1",
         "react-test-renderer": "^18.2.0",
@@ -15000,10 +15001,29 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-ga4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
       "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -15179,6 +15199,14 @@
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-test-renderer": {

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",
+    "react-helmet": "^6.1.0",
     "react-router-dom": "^6.8.1",
     "react-scripts": "^5.0.1",
     "react-test-renderer": "^18.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",
     "react-helmet": "^6.1.0",
+    "react-helmet-async": "^1.3.0",
     "react-router-dom": "^6.8.1",
     "react-scripts": "^5.0.1",
     "react-test-renderer": "^18.2.0",

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,7 +11,6 @@
     <meta name="theme-color" content="#ffffff" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="title" content="Explain AI" data-react-helmet="true" />
     <meta
       name="description"
       content="Explain it to me. Simply. (index.html)"
@@ -31,7 +30,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <!-- <title>Explain AI</title> -->
+    <title>Explain AI (index.html)</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,11 +11,11 @@
     <meta name="theme-color" content="#ffffff" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
+    <!-- <meta
       name="description"
       content="Explain it to me. Simply. (index.html)"
       data-react-helmet="true"
-    />
+    /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,7 +11,7 @@
     <meta name="theme-color" content="#ffffff" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Explain it to me. Simply." />
+    <!-- <meta name="description" content="Explain it to me. Simply." /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -26,7 +26,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Explain AI</title>
+    <!-- <title>Explain AI</title> -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -33,7 +33,7 @@
     <title>Explain AI (index.html)</title>
     <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
     <meta property="og:description" content="Home Page" data-react-helmet="true" />
-    <link rel="canonical" href="https://deploy-preview-118--explain-ai.netlify.app/javascript" />
+    <!-- <link rel="canonical" href="https://deploy-preview-118--explain-ai.netlify.app/" /> -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -33,7 +33,6 @@
     <title>Explain AI (index.html)</title>
     <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
     <meta property="og:description" content="Home Page" data-react-helmet="true" />
-    <meta property="og:url" content="https://deploy-preview-118--explain-ai.netlify.app/" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,7 +11,8 @@
     <meta name="theme-color" content="#ffffff" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- <meta name="description" content="Explain it to me. Simply." /> -->
+    <meta name="title" content="Explain AI" data-react-helmet="true" />
+    <meta name="description" content="Explain it to me. Simply." data-react-helmet="true" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -12,7 +12,11 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="title" content="Explain AI" data-react-helmet="true" />
-    <meta name="description" content="Explain it to me. Simply." data-react-helmet="true" />
+    <meta
+      name="description"
+      content="Explain it to me. Simply. (index.html)"
+      data-react-helmet="true"
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -30,7 +30,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Explain AI (index.html)</title>
+
     <!-- <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
     <meta property="og:description" content="Home Page" data-react-helmet="true" /> -->
     <!-- <link rel="canonical" href="https://deploy-preview-118--explain-ai.netlify.app/" /> -->

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,7 +11,7 @@
     <meta name="theme-color" content="#ffffff" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- <meta name="description" content="Explain it to me. Simply." /> -->
+    <meta name="description" content="Explain it to me. Simply." />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -26,7 +26,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <!-- <title>Explain AI</title> -->
+    <title>Explain AI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -31,6 +31,9 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Explain AI (index.html)</title>
+    <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
+    <meta property="og:description" content="Home Page" data-react-helmet="true" />
+    <meta property="og:url" content="https://deploy-preview-118--explain-ai.netlify.app/" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -33,6 +33,7 @@
     <title>Explain AI (index.html)</title>
     <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
     <meta property="og:description" content="Home Page" data-react-helmet="true" />
+    <link rel="canonical" href="https://deploy-preview-118--explain-ai.netlify.app/javascript" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -31,8 +31,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Explain AI (index.html)</title>
-    <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
-    <meta property="og:description" content="Home Page" data-react-helmet="true" />
+    <!-- <meta property="og:title" content="Explain AI (index.html)" data-react-helmet="true" />
+    <meta property="og:description" content="Home Page" data-react-helmet="true" /> -->
     <!-- <link rel="canonical" href="https://deploy-preview-118--explain-ai.netlify.app/" /> -->
   </head>
   <body>

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,7 +1,5 @@
 import React, { useEffect } from "react"; // eslint-disable-next-line
 import ReactGA from "react-ga4";
-// eslint-disable-next-line
-import { Helmet } from "react-helmet";
 import AudienceContext from "./components/AudienceContext";
 import AppRouter from "./AppRouter/AppRouter";
 import Header from "./Global/Header/Header";
@@ -18,10 +16,6 @@ function App() {
   return (
     <AudienceContext>
       <div className="App">
-        <Helmet>
-          <title>My Title</title>
-          <meta name="description" content="Explain it to me. Simply." />
-        </Helmet>
         <Header />
         <AppRouter />
       </div>

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,5 +1,7 @@
 import React, { useEffect } from "react"; // eslint-disable-next-line
 import ReactGA from "react-ga4";
+// eslint-disable-next-line
+import { Helmet } from "react-helmet";
 import AudienceContext from "./components/AudienceContext";
 import AppRouter from "./AppRouter/AppRouter";
 import Header from "./Global/Header/Header";
@@ -16,6 +18,10 @@ function App() {
   return (
     <AudienceContext>
       <div className="App">
+        <Helmet>
+          <title>My Title</title>
+          <meta name="description" content="Explain it to me. Simply." />
+        </Helmet>
         <Header />
         <AppRouter />
       </div>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -7,7 +7,7 @@ export default function HomePage() {
     <div>
       <Helmet>
         {/* <title>My Title</title> */}
-        <meta property="title" content="Explain AI" />
+        <meta property="og:title" content="og:Explain AI" />
         <meta property="og:description" content="og:Explain it to me. Simply." />
       </Helmet>
       <h1>Homepage</h1>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -19,6 +19,10 @@ export default function HomePage() {
             content="https://example.com/my-image.jpg"
             data-react-helmet="true"
           />
+          <link
+            rel="canonical"
+            href="https://deploy-preview-118--explain-ai.netlify.app/javascript"
+          />
         </Helmet>
         <h1>Homepage</h1>
         <a href="/javascript">javascript</a>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -1,21 +1,24 @@
 import React from "react";
 // eslint-disable-next-line
-import { Helmet } from "react-helmet";
+import Helmet, { HelmetProvider } from "react-helmet-async";
+// import { Helmet } from "react-helmet";
 
 export default function HomePage() {
   return (
-    <div>
-      <Helmet>
-        {/* <title>My Title</title> */}
-        <title>Explain AI</title>
-        <meta
-          property="og:description"
-          content="Explain it to me. Simply."
-          data-react-helmet="true"
-        />
-      </Helmet>
-      <h1>Homepage</h1>
-      <a href="/javascript">javascript</a>
-    </div>
+    <HelmetProvider>
+      <div>
+        <Helmet>
+          {/* <title>My Title</title> */}
+          <title>Explain AI</title>
+          <meta
+            property="og:description"
+            content="Explain it to me. Simply."
+            data-react-helmet="true"
+          />
+        </Helmet>
+        <h1>Homepage</h1>
+        <a href="/javascript">javascript</a>
+      </div>
+    </HelmetProvider>
   );
 }

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -7,7 +7,7 @@ export default function HomePage() {
     <div>
       <Helmet>
         {/* <title>My Title</title> */}
-        <meta property="og:title" content="Explain AI" data-react-helmet="true" />
+        <title>Explain AI</title>
         <meta
           property="og:description"
           content="Explain it to me. Simply."

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -19,10 +19,7 @@ export default function HomePage() {
             content="https://example.com/my-image.jpg"
             data-react-helmet="true"
           />
-          <link
-            rel="canonical"
-            href="https://deploy-preview-118--explain-ai.netlify.app/javascript"
-          />
+          <link rel="canonical" href="https://deploy-preview-118--explain-ai.netlify.app/" />
         </Helmet>
         <h1>Homepage</h1>
         <a href="/javascript">javascript</a>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -14,6 +14,11 @@ export default function HomePage() {
             content="Explain it to me. Simply."
             data-react-helmet="true"
           />
+          <meta
+            property="og:image"
+            content="https://example.com/my-image.jpg"
+            data-react-helmet="true"
+          />
         </Helmet>
         <h1>Homepage</h1>
         <a href="/javascript">javascript</a>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -7,7 +7,7 @@ export default function HomePage() {
     <div>
       <Helmet>
         <title>My Title</title>
-        <meta name="description" content="Explain it to me. Simply." />
+        <meta name="og:description" content="og:Explain it to me. Simply." />
       </Helmet>
       <h1>Homepage</h1>
       <a href="/javascript">javascript</a>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -1,6 +1,6 @@
 import React from "react";
 // eslint-disable-next-line
-import Helmet, { HelmetProvider } from "react-helmet-async";
+import { Helmet, HelmetProvider } from "react-helmet-async";
 // import { Helmet } from "react-helmet";
 
 export default function HomePage() {

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -6,7 +6,8 @@ export default function HomePage() {
   return (
     <div>
       <Helmet>
-        <title>My Title</title>
+        {/* <title>My Title</title> */}
+        <meta property="title" content="Explain AI" />
         <meta property="og:description" content="og:Explain it to me. Simply." />
       </Helmet>
       <h1>Homepage</h1>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -1,8 +1,14 @@
 import React from "react";
+// eslint-disable-next-line
+import { Helmet } from "react-helmet";
 
 export default function HomePage() {
   return (
     <div>
+      <Helmet>
+        <title>My Title</title>
+        <meta name="description" content="Explain it to me. Simply." />
+      </Helmet>
       <h1>Homepage</h1>
       <a href="/javascript">javascript</a>
     </div>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -7,10 +7,10 @@ export default function HomePage() {
     <div>
       <Helmet>
         {/* <title>My Title</title> */}
-        <meta property="og:title" content="og:Explain AI" data-react-helmet="true" />
+        <meta property="og:title" content="Explain AI" data-react-helmet="true" />
         <meta
           property="og:description"
-          content="og:Explain it to me. Simply."
+          content="Explain it to me. Simply."
           data-react-helmet="true"
         />
       </Helmet>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -7,7 +7,7 @@ export default function HomePage() {
     <div>
       <Helmet>
         <title>My Title</title>
-        <meta name="og:description" content="og:Explain it to me. Simply." />
+        <meta property="og:description" content="og:Explain it to me. Simply." />
       </Helmet>
       <h1>Homepage</h1>
       <a href="/javascript">javascript</a>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -7,8 +7,12 @@ export default function HomePage() {
     <div>
       <Helmet>
         {/* <title>My Title</title> */}
-        <meta property="og:title" content="og:Explain AI" />
-        <meta property="og:description" content="og:Explain it to me. Simply." />
+        <meta property="og:title" content="og:Explain AI" data-react-helmet="true" />
+        <meta
+          property="og:description"
+          content="og:Explain it to me. Simply."
+          data-react-helmet="true"
+        />
       </Helmet>
       <h1>Homepage</h1>
       <a href="/javascript">javascript</a>

--- a/web/src/Pages/HomePage/HomePage.js
+++ b/web/src/Pages/HomePage/HomePage.js
@@ -8,8 +8,7 @@ export default function HomePage() {
     <HelmetProvider>
       <div>
         <Helmet>
-          {/* <title>My Title</title> */}
-          <title>Explain AI</title>
+          <meta property="og:title" content="Explain AI" data-react-helmet="true" />
           <meta
             property="og:description"
             content="Explain it to me. Simply."

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -48,8 +48,8 @@ export default function TopicPage() {
     return (
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
-          <title>TopicPage</title>
-          <meta property="og:description" content="og:Helmet application" />
+          <meta property="title" content="Topic Page" />
+          <meta property="og:description" content="og:topic description" />
         </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -48,7 +48,7 @@ export default function TopicPage() {
     return (
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
-          <meta property="og:title" content="Topic Page" />
+          <title>Javascript</title>
           <meta property="og:description" content="topic description" />
         </Helmet>
         <Breadcrumbs

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -48,8 +48,8 @@ export default function TopicPage() {
     return (
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
-          <meta property="og:title" content="og:Topic Page" />
-          <meta property="og:description" content="og:topic description" />
+          <meta property="og:title" content="Topic Page" />
+          <meta property="og:description" content="topic description" />
         </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -49,7 +49,7 @@ export default function TopicPage() {
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
           <title>TopicPage</title>
-          <meta name="description" content="Helmet application" />
+          <meta name="og:description" content="og:Helmet application" />
         </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -48,7 +48,7 @@ export default function TopicPage() {
     return (
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
-          <meta property="title" content="Topic Page" />
+          <meta property="og:title" content="og:Topic Page" />
           <meta property="og:description" content="og:topic description" />
         </Helmet>
         <Breadcrumbs

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -49,7 +49,7 @@ export default function TopicPage() {
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
           <title>TopicPage</title>
-          <meta name="og:description" content="og:Helmet application" />
+          <meta property="og:description" content="og:Helmet application" />
         </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -6,6 +6,8 @@ import TopicCard from "./TopicCard/TopicCard";
 import ErrorMessage from "../../components/ErrorMessage";
 import RelationCard from "./RelationCard/RelationCard";
 import { ageContext } from "../../components/AudienceContext";
+// eslint-disable-next-line
+import { Helmet } from "react-helmet";
 import { audienceChangeOnSubjectEvent } from "../../utils/gaEvents";
 
 export default function TopicPage() {
@@ -45,6 +47,10 @@ export default function TopicPage() {
   if (topicData?.descriptions.length) {
     return (
       <div className="mt-[80px] phone:mt-[70.5px]">
+        <Helmet>
+          <title>TopicPage</title>
+          <meta name="description" content="Helmet application" />
+        </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}
           grandParent={topicData.parent.parent.grandparent.grandparent}

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -50,9 +50,9 @@ export default function TopicPage() {
         <Helmet>
           <meta property="og:title" content="Topic" data-react-helmet="true" />
           <meta property="og:description" content="topic description" data-react-helmet="true" />
-          <meta
-            property="og:url"
-            content="https://deploy-preview-118--explain-ai.netlify.app/javascript"
+          <link
+            rel="canonical"
+            href="https://deploy-preview-118--explain-ai.netlify.app/javascript"
           />
         </Helmet>
         <Breadcrumbs

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -50,6 +50,10 @@ export default function TopicPage() {
         <Helmet>
           <meta property="og:title" content="Topic" data-react-helmet="true" />
           <meta property="og:description" content="topic description" data-react-helmet="true" />
+          <meta
+            property="og:url"
+            content="https://deploy-preview-118--explain-ai.netlify.app/javascript"
+          />
         </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}

--- a/web/src/Pages/TopicPage/TopicPage.js
+++ b/web/src/Pages/TopicPage/TopicPage.js
@@ -48,8 +48,8 @@ export default function TopicPage() {
     return (
       <div className="mt-[80px] phone:mt-[70.5px]">
         <Helmet>
-          <title>Javascript</title>
-          <meta property="og:description" content="topic description" />
+          <meta property="og:title" content="Topic" data-react-helmet="true" />
+          <meta property="og:description" content="topic description" data-react-helmet="true" />
         </Helmet>
         <Breadcrumbs
           parent={topicData.parent.parent}


### PR DESCRIPTION
When using the 'Helmet' library to dynamically update meta tags depending on the webpage, it computes the meta tags once the website is loaded. Thus, crawlers which are responsible for showing the previews in applications such as Slack are unable to make use of it since they do not compute the meta tags inside react components and take on the value in the `index.html` file's `<head>` element which are only useful for the Home page. Dynamic meta tags can only be implemented using 'server-side' rendering.

More resources for explanation here:
https://github.com/nfl/react-helmet/issues/26#issuecomment-339128792