### PR TITLE
Handle group members missing descriptions

### DIFF
--- a/web/src/Pages/HomePage/HomePageCard/HomePageCard.jsx
+++ b/web/src/Pages/HomePage/HomePageCard/HomePageCard.jsx
@@ -17,24 +17,17 @@ export default function HomePageCard({ group, audience }) {
       </div>
       <br />
       <ul>
-        {group.items.map((item) => {
-          const hasBeenGenerated = item.topic.descriptions?.[ageIndex]?.extra_short;
-          return (
-            <li key={item.topic.name}>
-              <RelationCard
-                slug={item.topic.slug}
-                name={item.topic.name}
-                description={
-                  hasBeenGenerated
-                    ? item.topic.descriptions[ageIndex].extra_short
-                    : "Click to generate"
-                }
-                image={item.topic.image}
-                parent={group.name}
-              />
-            </li>
-          );
-        })}
+        {group.items.map((item) => (
+          <li key={item.topic.name}>
+            <RelationCard
+              slug={item.topic.slug}
+              name={item.topic.name}
+              description={item.topic.descriptions?.[ageIndex]?.extra_short || "Click to generate"}
+              image={item.topic.image}
+              parent={group.name}
+            />
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/web/src/Pages/HomePage/HomePageCard/HomePageCard.jsx
+++ b/web/src/Pages/HomePage/HomePageCard/HomePageCard.jsx
@@ -17,17 +17,24 @@ export default function HomePageCard({ group, audience }) {
       </div>
       <br />
       <ul>
-        {group.items.map((item) => (
-          <li key={item.topic.name}>
-            <RelationCard
-              slug={item.topic.slug}
-              name={item.topic.name}
-              description={item.topic.descriptions[ageIndex].extra_short}
-              image={item.topic.image}
-              parent={group.name}
-            />
-          </li>
-        ))}
+        {group.items.map((item) => {
+          const hasBeenGenerated = item.topic.descriptions?.[ageIndex]?.extra_short;
+          return (
+            <li key={item.topic.name}>
+              <RelationCard
+                slug={item.topic.slug}
+                name={item.topic.name}
+                description={
+                  hasBeenGenerated
+                    ? item.topic.descriptions[ageIndex].extra_short
+                    : "Click to generate"
+                }
+                image={item.topic.image}
+                parent={group.name}
+              />
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
Before we required all members of a group to have a description generated, this removes that requirement